### PR TITLE
short enclosure urls

### DIFF
--- a/app/models/pmp_guid_mapping.rb
+++ b/app/models/pmp_guid_mapping.rb
@@ -17,5 +17,4 @@ class PMPGuidMapping < ActiveRecord::Base
   def self.new_guid
     SecureRandom.uuid
   end
-
 end

--- a/app/models/prx_importer.rb
+++ b/app/models/prx_importer.rb
@@ -240,7 +240,8 @@ class PRXImporter < ApplicationImporter
     href = audio.enclosure.href
     type = audio.body['_links']['enclosure']['type']
 
-    enclosure_url = count_audio_url(href, audio.id, prx_piece_id, adoc.guid)
+    # enclosure_url = count_audio_url(href, audio.id, prx_piece_id, adoc.guid)
+    enclosure_url = prx_web_link(href)
 
     add_link_to_doc(adoc, 'enclosure', { href: enclosure_url, type: type, meta: {duration: audio.duration, size: audio.size} })
 
@@ -336,7 +337,7 @@ class PRXImporter < ApplicationImporter
   end
 
   def prx_web_link(path)
-    "#{prx_web_endpoint}#{path}"
+    URI.join(prx_web_endpoint, path).to_s
   end
 
   def tag_for_url(source, url)
@@ -353,5 +354,4 @@ class PRXImporter < ApplicationImporter
   def find_or_create_guid(type, prx_obj)
     PMPGuidMapping.find_or_create_guid(source_name, type, prx_url(prx_obj.self.href))
   end
-
 end

--- a/test/models/prx_importer_test.rb
+++ b/test/models/prx_importer_test.rb
@@ -184,7 +184,7 @@ describe PRXImporter do
 
         # create audio
         stub_request(:put, "https://publish.pmp.io/docs/9ff6db7a-93e6-4987-9313-4d70d74051b6").
-          with(:body => "{\"version\":\"1.0\",\"links\":{\"profile\":[{\"href\":\"https://api.pmp.io/profiles/audio\",\"type\":\"application/vnd.collection.doc+json\"}],\"enclosure\":[{\"href\":\"https://count.prx.org/redirect?action=request\\u0026action_value=%7B%22audioFileId%22%3A451642%2C%22pieceId%22%3A87683%7D\\u0026location=https%3A%2F%2Fcms.prx.org%2Fpub%2F472875466d225aca0480000fea4b5fc2%2F0%2Fweb%2Faudio_file%2F451642%2Fbroadcast%2FMoth1301GarrisonFinal.mp3\\u0026prx_story_id=87683\\u0026referrer=https%3A%2F%2Fapi.pmp.io%2Fdocs%2F9ff6db7a-93e6-4987-9313-4d70d74051b6\",\"type\":\"audio/mpeg\",\"meta\":{\"duration\":3179,\"size\":101617830}}]},\"attributes\":{\"guid\":\"9ff6db7a-93e6-4987-9313-4d70d74051b6\",\"title\":\"Moth 1301 Single File\",\"tags\":[\"PRX\"],\"itags\":[\"prx_test\",\"prx:audio_files-451642\"]}}").
+          with(:body => "{\"version\":\"1.0\",\"links\":{\"profile\":[{\"href\":\"https://api.pmp.io/profiles/audio\",\"type\":\"application/vnd.collection.doc+json\"}],\"enclosure\":[{\"href\":\"https://www.prx.org/pub/472875466d225aca0480000fea4b5fc2/0/web/audio_file/451642/broadcast/Moth1301GarrisonFinal.mp3\",\"type\":\"audio/mpeg\",\"meta\":{\"duration\":3179,\"size\":101617830}}]},\"attributes\":{\"guid\":\"9ff6db7a-93e6-4987-9313-4d70d74051b6\",\"title\":\"Moth 1301 Single File\",\"tags\":[\"PRX\"],\"itags\":[\"prx_test\",\"prx:audio_files-451642\"]}}").
           to_return(:status => 200, :body => '{"url":"https://api.pmp.io/docs/9ff6db7a-93e6-4987-9313-4d70d74051b6"}', :headers => {})
 
         # ... Story Finish


### PR DESCRIPTION
The NPR DS Core Publisher CMS is based on Drupal, and is apparently unable to handle media urls larger than 255 characters.

This fix is tactical: by removing the count.prx.org redirect, we reduce the url length below the limit.

The longer term fix will be to implement both the count and and cdn capabilities for media urls in the prx api.